### PR TITLE
Use self-times instead of including all nested trees...

### DIFF
--- a/app/components/slow-node-times.js
+++ b/app/components/slow-node-times.js
@@ -79,13 +79,13 @@ export default Ember.Component.extend({
       let pluginNameMap = nodes.reduce((memo, node) => {
         let pluginName = node.label.broccoliPluginName;
         memo[pluginName] = memo[pluginName] || { count: 0, time: 0 };
-        memo[pluginName].time += node._stats.time.plugin;
+        memo[pluginName].time += node._stats.time.self;
         memo[pluginName].count++;
         return memo;
       }, {});
 
       nodes = [];
-      
+
       for (let pluginName in pluginNameMap) {
         nodes.push({
           groupedByPluginName: true,
@@ -112,7 +112,7 @@ export default Ember.Component.extend({
     // off the label as the plugin name. If not, we need
     // to create a map of the plugin names and return that.
     let pluginNames = [];
-    
+
     if (nodes[0].groupedByPluginName === true) {
       pluginNames = nodes.map(node => node.label.name);
     } else {
@@ -132,11 +132,12 @@ export default Ember.Component.extend({
 
   sortedNodes: computed('nodes', 'sortDescending', function() {
     let sortDescending = this.get('sortDescending');
+    let field = this.get('groupByPluginName') ? 'plugin' : 'self';
     return this.get('nodes').sort((a, b) => {
       if (sortDescending) {
-        return b._stats.time.plugin - a._stats.time.plugin;
+        return b._stats.time[field] - a._stats.time[field];
       } else {
-        return a._stats.time.plugin - b._stats.time.plugin;
+        return a._stats.time[field] - b._stats.time[field];
       }
     });
   }).readOnly(),
@@ -145,7 +146,7 @@ export default Ember.Component.extend({
     let nodes = this.get('nodes');
 
     return nodes.reduce(function(previousValue, node){
-      return previousValue + node._stats.time.plugin;
+      return previousValue + node._stats.time.self;
     }, 0);
   }).readOnly(),
 

--- a/app/templates/components/slow-node-times.hbs
+++ b/app/templates/components/slow-node-times.hbs
@@ -12,7 +12,7 @@
            {{#if pluginNameFilter}}
              <option value="clearFilter">Clear Filter</option>
            {{/if}}
-        </select>        
+        </select>
       </p>
     </div>
 
@@ -33,7 +33,7 @@
       <th>Description</th>
       <th>{{if groupByPluginName "Count" "Plugin Name"}}</th>
       <th class="td-time">
-        <a href="#" class="nodes-table_toggle" {{action "toggleTime"}}>Time (ms) <i class="fa fa-caret-{{if sortDescending 'down' 'up'}}"></i></a>
+        <a href="#" class="nodes-table_toggle" {{action "toggleTime"}}>Self Time (ms) <i class="fa fa-caret-{{if sortDescending 'down' 'up'}}"></i></a>
       </th>
     </tr>
   </thead>
@@ -43,7 +43,13 @@
       <tr class="table-row" {{action 'toggleDetailsForNode' node}}>
         <td>{{node.label.name}}</td>
         <td class="table-row-plugin-name">{{node.label.broccoliPluginName}}</td>
-        <td class="td-time">{{ns-to-ms node._stats.time.plugin}}</td>
+        <td class="td-time">
+          {{#if groupByPluginName}}
+            {{ns-to-ms node._stats.time.plugin}}
+          {{else}}
+            {{ns-to-ms node._stats.time.self}}
+          {{/if}}
+        </td>
       </tr>
       {{#if node.showDetails}}
         <tr>


### PR DESCRIPTION
I don't understand what the point is of including the time of all nested trees in the numbers, so I changed it to just use "self" times, so we could analyze what a particular plugin's impact was/is.